### PR TITLE
Gradle 6.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Sun Sep 22 23:49:02 EEST 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Gradle 6.2 is available.

This is sent by @gradleupdate. See https://gradleupdate.appspot.com/head-thrash/guardrail-gradle-plugin/status for more.